### PR TITLE
refactor: remove import react using tsconfig compileOption

### DIFF
--- a/src/app/article/[articleNo]/page.tsx
+++ b/src/app/article/[articleNo]/page.tsx
@@ -1,5 +1,4 @@
 import { Box } from "@radix-ui/themes";
-import React from "react";
 
 export default function ArticleDetailPage({ params }: { params: { articleNo: string } }) {
   const articleNo = params.articleNo;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,7 @@
     "moduleResolution": "node",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "preserve",
+    "jsx": "react-jsx",
     "incremental": true,
     "plugins": [
       {


### PR DESCRIPTION
> 'React' refers to a UMD global, but the current file is a module. Consider adding an import instead.ts

## 개요
Next.js에서는 React17부터 import를 babel쪽에서 처리해줘서 없이 사용 가능합니다.
https://nextjs.org/docs/pages/building-your-application/upgrading/version-11#react-16-to-17

## 상황 1) compile error
출력기준 jsx compile option을 preserve(원본)에서 react-jsx로 바꿔줍니다.
https://www.typescriptlang.org/ko/docs/handbook/jsx.html

```json
{
  "compilerOptions": {
     // "jsx": "preserve" // AS-IS
    "jsx": "react-jsx" // TO-BE
  }
}
```

## 상황 2) eslint error
eslint에서 해당 rule을 off시켜줍니다.
```json
  "react/react-in-jsx-scope": 0,
```
