### PR TITLE
feat: posts page 구현

### DIFF
--- a/src/api/notion.ts
+++ b/src/api/notion.ts
@@ -126,8 +126,6 @@ export const searchArticle = async (key: string) => {
         properties: item.properties
       };
     });
-
-    console.log(titleList);
     return titleList;
   } catch (error) {
     console.error("Error in searchArticle function:", error);

--- a/src/api/notion.ts
+++ b/src/api/notion.ts
@@ -5,7 +5,7 @@ import {
 } from "@notionhq/client/build/src/api-endpoints";
 
 import { NotionToMarkdown } from "notion-to-md";
-import { Article } from "./types";
+import { Article, MultiSelectOption } from "./types";
 
 export const notionClient = new Client({
   auth: process.env.NOTION_TOKEN
@@ -144,28 +144,22 @@ export async function getPostPage(pageId: string): Promise<PostPage> {
   try {
     const pageInfo = await getPageInfo(pageId);
     const nameProperty = pageInfo.properties.name;
-    console.log("nameProperty type:", nameProperty?.type);
-
     const title =
       nameProperty?.type === "title" && nameProperty.title?.[0]?.plain_text
         ? nameProperty.title[0].plain_text
         : "제목 없음";
-
     const createdAt = new Date(pageInfo.created_time);
-
     const roleProperty = pageInfo.properties.role;
-    console.log("roleProperty type:", roleProperty?.type);
-
     const role =
       roleProperty?.type === "multi_select" && roleProperty.multi_select
-        ? roleProperty.multi_select.map((selectItem: any) => selectItem.name).join(", ")
+        ? roleProperty.multi_select
+            .map((selectItem: MultiSelectOption) => selectItem.name)
+            .join(", ")
         : "None";
-
     const coverImageUrl =
       pageInfo.cover?.type === "file" && pageInfo.cover.file
         ? pageInfo.cover.file.url
         : "/default_cover_image.png";
-
     return {
       pageId,
       title,

--- a/src/api/notion.ts
+++ b/src/api/notion.ts
@@ -146,10 +146,13 @@ export async function getPostPage(pageId: string) {
     const roleProperty = pageInfo.properties.role as any;
     const role =
       roleProperty?.multi_select?.map((selectItem: any) => selectItem.name).join(", ") || "None";
+    const coverImageUrl =
+      pageInfo.cover?.type === "file" ? pageInfo.cover?.file.url : "/default_cover_image.png";
     return {
       title,
       createdAt,
-      role
+      role,
+      coverImageUrl
     };
   } catch (error) {
     console.error("Error fetching postPage:", error);

--- a/src/api/notion.ts
+++ b/src/api/notion.ts
@@ -132,3 +132,27 @@ export const searchArticle = async (key: string) => {
     throw new Error("Error in searchArticle function");
   }
 };
+
+/*
+ * pageId로 title, createdAt, role을 가져오는 함수
+ */
+
+export async function getPostPage(pageId: string) {
+  try {
+    const pageInfo = await getPageInfo(pageId);
+    const itemName = pageInfo.properties.name as any;
+    const title = itemName?.title?.[0]?.plain_text || "제목 없음";
+    const createdAt = new Date(pageInfo.created_time);
+    const roleProperty = pageInfo.properties.role as any;
+    const role =
+      roleProperty?.multi_select?.map((selectItem: any) => selectItem.name).join(", ") || "None";
+    return {
+      title,
+      createdAt,
+      role
+    };
+  } catch (error) {
+    console.error("Error fetching postPage:", error);
+    throw error;
+  }
+}

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -5,3 +5,8 @@ export interface Article {
   thumbnailUrl: string;
   properties: any;
 }
+export interface MultiSelectOption {
+  id: string;
+  name: string;
+  color: string;
+}

--- a/src/app/posts/[postNo]/page.tsx
+++ b/src/app/posts/[postNo]/page.tsx
@@ -1,14 +1,36 @@
-import { fetchArticleContent } from "@/api/notion";
+import { fetchArticleContent, getPostPage } from "@/api/notion";
 import { PostRenderer } from "@/components/PostRenderer/PostRenderer";
-import { Flex } from "@radix-ui/themes";
+import { Badge, Box, Flex, Heading } from "@radix-ui/themes";
+import { getFormatDate } from "@/utils/getFormatDate";
 
 export default async function PostPage({ params }: { params: { postNo: string } }) {
   const pageId = params.postNo;
   const content = await fetchArticleContent(pageId);
+  const postInfo = await getPostPage(pageId);
 
   return (
-    <Flex width="100%" direction="column" align="center">
-      <Flex px="5" direction="column" maxWidth="540px">
+    <Flex
+      width="100%"
+      direction="column"
+      align="center"
+      px={{ initial: "4", md: "6", lg: "8" }}
+      py="5"
+    >
+      <Flex
+        width="100%"
+        maxWidth="1200px"
+        direction="column"
+        gap={{ initial: "3", md: "4", lg: "6" }}
+      >
+        <Heading size={{ initial: "5", md: "6", lg: "7" }}>{postInfo.title}</Heading>
+        <Heading size="2" color="gray">
+          {getFormatDate(postInfo.createdAt)}
+        </Heading>
+        <Box maxWidth="200px">
+          <Badge size="3" color="gray" radius="full">
+            {postInfo.role}
+          </Badge>
+        </Box>
         <PostRenderer content={content.parent} />
       </Flex>
     </Flex>

--- a/src/app/posts/[postNo]/page.tsx
+++ b/src/app/posts/[postNo]/page.tsx
@@ -2,6 +2,7 @@ import { fetchArticleContent, getPostPage } from "@/api/notion";
 import { PostRenderer } from "@/components/PostRenderer/PostRenderer";
 import { Badge, Box, Flex, Heading } from "@radix-ui/themes";
 import { getFormatDate } from "@/utils/getFormatDate";
+import Image from "next/image";
 
 export default async function PostPage({ params }: { params: { postNo: string } }) {
   const pageId = params.postNo;
@@ -22,7 +23,14 @@ export default async function PostPage({ params }: { params: { postNo: string } 
         direction="column"
         gap={{ initial: "3", md: "4", lg: "6" }}
       >
-        <p>이미지</p>
+        <Image
+          src={postInfo.coverImageUrl || ""}
+          alt={`${postInfo.title}의 썸네일 이미지`}
+          width={200}
+          height={200}
+          style={{ objectFit: "cover", width: "100%", height: 300, borderRadius: 10 }}
+          priority
+        />
         <Heading size={{ initial: "7", md: "8", lg: "9" }}>{postInfo.title}</Heading>
         <Heading size="2" color="gray">
           {getFormatDate(postInfo.createdAt)}

--- a/src/app/posts/[postNo]/page.tsx
+++ b/src/app/posts/[postNo]/page.tsx
@@ -22,7 +22,8 @@ export default async function PostPage({ params }: { params: { postNo: string } 
         direction="column"
         gap={{ initial: "3", md: "4", lg: "6" }}
       >
-        <Heading size={{ initial: "5", md: "6", lg: "7" }}>{postInfo.title}</Heading>
+        <p>이미지</p>
+        <Heading size={{ initial: "7", md: "8", lg: "9" }}>{postInfo.title}</Heading>
         <Heading size="2" color="gray">
           {getFormatDate(postInfo.createdAt)}
         </Heading>

--- a/src/app/posts/[postNo]/page.tsx
+++ b/src/app/posts/[postNo]/page.tsx
@@ -24,7 +24,7 @@ export default async function PostPage({ params }: { params: { postNo: string } 
         gap={{ initial: "3", md: "4", lg: "6" }}
       >
         <Image
-          src={postInfo.coverImageUrl || ""}
+          src={postInfo.thumbnailUrl || ""}
           alt={`${postInfo.title}의 썸네일 이미지`}
           width={200}
           height={200}


### PR DESCRIPTION
## 📝 PR 유형

- [x] 🚀 feature 기능 추가
- [ ] 🐞 버그 발생
- [ ] 🔨 리팩토링
- [ ] 📋 문서작성
- [ ] 🌍 빌드 설정 및 문제
- [ ] ETC

## 📝 PR 설명

posts page 구현
- 제목, 날짜, 태그 렌더링
- 반응형 작업

## 관련된 이슈 넘버

## ✅ 작업 목록

- 제목(title), 날짜(createdAt), 태그(role) 받아 해당하는 페이지에 맞도록 렌더링
```
export async function getPostPage(pageId: string) {
  try {
    const pageInfo = await getPageInfo(pageId);
    const itemName = pageInfo.properties.name as any;
    const title = itemName?.title?.[0]?.plain_text || "제목 없음";
    const createdAt = new Date(pageInfo.created_time);
    const roleProperty = pageInfo.properties.role as any;
    const role =
      roleProperty?.multi_select?.map((selectItem: any) => selectItem.name).join(", ") || "None";
    return {
      title,
      createdAt,
      role
    };
  } catch (error) {
    console.error("Error fetching postPage:", error);
    throw error;
  }
}
```
getPageInfo를 이용해 페이지 정보를 받아와 제목, 날짜, 태그를 받아 오고 있습니다. 현재 상황에서는 아직 태그의 종류가 많지 않고 분류가 크게 되어 있어 굳이 필요는 없을 것 같지만 추후에 role(태그)가 많아질 때를 대비해 변수에 하나 이상의 roleProperty를 담도록 만들었습니다.

- radix 라이브러리 반응형 설정
https://www.radix-ui.com/themes/docs/theme/breakpoints
해당 페이지 참고해서 initial(모바일), md(중간), lg(큰화면)으로 스타일 지정했습니다. 또한 부모 컴포넌트 Flex 태그에 maxWidth="1200px" 지정해서 큰 화면일 때 사이즈가 너무 넓어지는 것을 방지했습니다.

---
### 코드리뷰 반영 사항
## 1. 상세 페이지 상단에 커버 이미지 불러오도록 수정했습니다.
기존 getArticleInfoList 함수 참고했습니다. (현재 커버 이미지 타입이 파일일 경우 해당 파일을 커버 이미지 url을 불러오고, 파일이 아닐 경우 /default_cover_image.png 이미지를 보여주고 있습니다.)
<img width="663" alt="image" src="https://github.com/user-attachments/assets/1c309e10-a6e3-4ffa-9fc8-87e7c3f83ad9">

## 2. 타입 명시
getPostPage에서 작성했던 기존 any 타입을 명시적으로 바꾸었습니다. 기존 Article 인터페이스 활용, 추가적인 데이터인 role 반환을 위해 새 인터페이스 확장했습니다.
```
interface PostPage extends Article {
  role: string;
}
```
multi_select나 title은 특정 속성 타입에서만 존재하는 필드입니다. 따라서 특정 타입에 접근할 때 타입 검사를 추가했습니다.
- pageInfo.properties.name가 title 타입인지
- pageInfo.properties.role이 multi_select 타입인지
```
    const nameProperty = pageInfo.properties.name;
    const title =
      nameProperty?.type === "title" && nameProperty.title?.[0]?.plain_text
        ? nameProperty.title[0].plain_text
        : "제목 없음";

    const roleProperty = pageInfo.properties.role;
    const role =
      roleProperty?.type === "multi_select" && roleProperty.multi_select
        ? roleProperty.multi_select
            .map((selectItem: MultiSelectOption) => selectItem.name)
            .join(", ")
        : "None";
```
또한, multi_select의 항목은 id, name, color 필드를 가져 MultiSelectOption 인터페이스를 추가해 selectItem을 MultiSelectOption 타입으로 지정했습니다.

multi_select 응답 예시 참고
```
[
  {
    id: '50e848-904a-489a-...',
    name: 'Frontend',
    color: 'yellow'
  }
]
```

## MR하기 전에 확인해주세요

- [x] local code lint 검사를 진행하셨나요?
- [x] loca ci test를 진행하셨나요?

## 📚 논의사항
- 커버 이미지 상세 페이지에서의 노출 여부
테스트 하다가 확인해보니, 노션의 커버 이미지가 파일로 등록할 때만 메인 페이지의 썸네일 이미지로 들어가고 있습니다. (노션이 제공하는 기본 커버 변경 방식 제외하고 파일로만 인식) 그리고 posts/[pageId] (상세 페이지) 에서는 커버 이미지가 보이지 않는데, 상세 페이지에서 커버 이미지를 보여줄지 말지 논의하고 싶습니다.

- 노션 api 중복해서 사용하고 있는지
일단 상세 페이지에서 데이터를 가져와 제목, 날짜, 태그를 보여주기 위해서 notion.ts 파일 임의로 수정하여 사용하고 있는데, 메인 페이지 작업하는 채정님이랑 나중에 한번 상의해야 할 것 같습니다. api 사용할 때 어느정도 일관성이나 재사용 가능한 코드로 함께 얘기해서 바꾸면 좋을 것 같습니다.

## 📚 ETC

https://github.com/user-attachments/assets/1c0abf4d-eaeb-48c7-9438-cf23f5fa8928

