### PR TITLE
feat: open graph 적용

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -10,7 +10,28 @@ const inter = Inter({ subsets: ["latin"] });
 
 export const metadata: Metadata = {
   title: "FotCamp Tech Blog",
-  description: "FotCamp Tech Blog"
+  description: "FotCamp Tech Blog",
+  openGraph: {
+    title: "FotCamp Tech Blog",
+    description: "FotCamp의 기술 블로그입니다.",
+    url: "https://blog.fin-hub.co.kr",
+    siteName: "FotCamp Tech Blog",
+    images: [
+      {
+        url: "https://blog.fin-hub.co.kr/default_cover_image.png",
+        width: 1200,
+        height: 630,
+        alt: "FotCamp Tech Blog Default Image"
+      }
+    ],
+    type: "website"
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "FotCamp Tech Blog",
+    description: "FotCamp의 기술 블로그입니다.",
+    images: ["https://blog.fin-hub.co.kr/default_cover_image.png"]
+  }
 };
 
 export default function RootLayout({

--- a/src/app/posts/[postNo]/page.tsx
+++ b/src/app/posts/[postNo]/page.tsx
@@ -3,6 +3,46 @@ import { PostRenderer } from "@/components/PostRenderer/PostRenderer";
 import { Badge, Box, Flex, Heading } from "@radix-ui/themes";
 import { getFormatDate } from "@/utils/getFormatDate";
 import Image from "next/image";
+import type { Metadata } from "next";
+
+export async function generateMetadata({
+  params
+}: {
+  params: { postNo: string };
+}): Promise<Metadata> {
+  const postInfo = await getPostPage(params.postNo);
+  const defaultImageUrl = "https://blog.fin-hub.co.kr/default_cover_image.png";
+  const imageUrl = postInfo.thumbnailUrl || defaultImageUrl;
+  const title = `${postInfo.title}`;
+  const description = "FotCamp 기술 블로그";
+  const pageUrl = `https://blog.fin-hub.co.kr/posts/${params.postNo}`;
+
+  return {
+    title,
+    description,
+    openGraph: {
+      title,
+      description,
+      url: pageUrl,
+      siteName: "FotCamp 기술 블로그",
+      images: [
+        {
+          url: imageUrl,
+          width: 1200,
+          height: 630,
+          alt: postInfo.title
+        }
+      ],
+      type: "article"
+    },
+    twitter: {
+      card: "summary_large_image",
+      title,
+      description,
+      images: [imageUrl]
+    }
+  };
+}
 
 export default async function PostPage({ params }: { params: { postNo: string } }) {
   const pageId = params.postNo;

--- a/src/app/posts/[postNo]/page.tsx
+++ b/src/app/posts/[postNo]/page.tsx
@@ -4,6 +4,7 @@ import { Badge, Box, Flex, Heading } from "@radix-ui/themes";
 import { getFormatDate } from "@/utils/getFormatDate";
 import Image from "next/image";
 import type { Metadata } from "next";
+import { headers } from "next/headers";
 
 export async function generateMetadata({
   params
@@ -15,7 +16,12 @@ export async function generateMetadata({
   const imageUrl = postInfo.thumbnailUrl || defaultImageUrl;
   const title = `${postInfo.title}`;
   const description = "FotCamp 기술 블로그";
-  const pageUrl = `https://blog.fin-hub.co.kr/posts/${params.postNo}`;
+
+  const headersList = headers();
+  const host = headersList.get("host") as string;
+  const protocol = headersList.get("x-forwarded-proto") || "http";
+  const origin = `${protocol}://${host}`;
+  const pageUrl = `${origin}/posts/${params.postNo}`;
 
   return {
     title,


### PR DESCRIPTION
## 📝 PR 유형

- [x] 🚀 feature 기능 추가
- [ ] 🐞 버그 발생
- [ ] 🔨 리팩토링
- [ ] 📋 문서작성
- [ ] 🌍 빌드 설정 및 문제
- [ ] ETC

## 📝 PR 설명
Open Graph Image 적용
<!-- PR 설명 -->

## 관련된 이슈 넘버

<!-- close #1 -->

## ✅ 작업 목록
작업한 것은 총 2가지 케이스입니다.
1. 글 상세 페이지 별 동적으로 적용
2. 1번 제외한 모든 경우 기본으로 적용

- 공통으로 적용되는 메타 태그 설정
Metadata 타입 활용해서 layout.tsx 파일 수정했습니다.
```
openGraph: {
    title: "FotCamp Tech Blog",
    description: "FotCamp의 기술 블로그입니다.",
    url: "https://blog.fin-hub.co.kr",
    siteName: "FotCamp Tech Blog",
    images: [
      {
        url: "https://blog.fin-hub.co.kr/default_cover_image.png",
        width: 1200,
        height: 630,
        alt: "FotCamp Tech Blog Default Image"
      }
    ],
    type: "website"
  },
  twitter: {
    card: "summary_large_image",
    title: "FotCamp Tech Blog",
    description: "FotCamp의 기술 블로그입니다.",
    images: ["https://blog.fin-hub.co.kr/default_cover_image.png"]
  }
};
```
- 상세 페이지 별 동적인 메타 태그 생성하기
generateMetadata 함수 사용했습니다. 매개변수로 params를 받는데, URL 경로에 있는 동적 매개변수를 포함하고 있습니다. /posts/[postNo] 같은 경로에서 [postNo] 값은 params.postNo로 전달됩니다.

## MR하기 전에 확인해주세요

- [x] local code lint 검사를 진행하셨나요?
- [x] loca ci test를 진행하셨나요?

## 📚 논의사항

<!-- 이 PR에서 더 논의할 사항 혹은 리뷰어에게 확인 요청하고 싶은 부분 기재 -->

## 📚 ETC
로컬 테스트 결과

기본, 검색 페이지, 검색 결과 페이지
<img width="311" alt="스크린샷 2024-09-12 오후 4 50 27" src="https://github.com/user-attachments/assets/67a809a9-4172-422f-af0c-dca078181eba">

글 상세 페이지 [posts/postId]
<img width="308" alt="스크린샷 2024-09-12 오후 5 00 26" src="https://github.com/user-attachments/assets/9effe98d-b561-45cc-93fa-6a32ba5b4a75">


